### PR TITLE
Add CLI route generator with multiple templates

### DIFF
--- a/docs/CLI_ROUTE_GENERATOR.md
+++ b/docs/CLI_ROUTE_GENERATOR.md
@@ -1,0 +1,291 @@
+# CLI Route Generator
+
+The CLI route generator provides a quick way to scaffold route handlers with pre-built templates. It supports basic routes, RESTful API endpoints, and full CRUD operations.
+
+## Installation
+
+The CLI is included with the Cenzero framework. After installing:
+
+```bash
+npm install -g cnzr
+# or use npx
+npx cnzr generate <route-name>
+```
+
+## Commands
+
+### Generate Route
+
+```bash
+cnzr generate <route-name> [options]
+# or
+cnzr g <route-name> [options]
+```
+
+### Options
+
+- `-m, --method <method>` - HTTP method (get, post, put, delete). Default: `get`
+- `-p, --path <path>` - Route path. Default: `/<route-name>`
+- `-d, --dir <directory>` - Output directory. Default: `src/routes`
+- `-t, --template <template>` - Template type (basic, api, crud). Default: `basic`
+
+## Templates
+
+### Basic Template
+
+Simple route handler with error handling:
+
+```bash
+cnzr generate users --method get --template basic
+```
+
+Generates `src/routes/users.ts`:
+
+```typescript
+import { CenzeroContext } from "cnzr";
+
+export async function usersHandler(ctx: CenzeroContext) {
+  try {
+    ctx.json({
+      message: "users route",
+      path: "/users",
+      method: "GET",
+    });
+  } catch (error: any) {
+    ctx.status(500).json({
+      error: "Internal server error",
+      message: error.message,
+    });
+  }
+}
+```
+
+Usage:
+```typescript
+import { usersHandler } from './src/routes/users';
+app.get('/users', usersHandler);
+```
+
+### API Template
+
+RESTful API handler with request validation:
+
+```bash
+cnzr generate createUser --method post --path /api/users --template api
+```
+
+Generates `src/routes/createUser.ts`:
+
+```typescript
+import { CenzeroContext } from "cnzr";
+
+export async function createUserHandler(ctx: CenzeroContext) {
+  try {
+    // Validate request
+    if (!ctx.body) {
+      return ctx.status(400).json({
+        error: "Bad Request",
+        message: "Request body is required",
+      });
+    }
+
+    const result = {
+      success: true,
+      data: ctx.body,
+      timestamp: new Date().toISOString(),
+    };
+
+    ctx.json(result);
+  } catch (error: any) {
+    ctx.status(500).json({
+      error: "Internal Server Error",
+      message: error.message,
+    });
+  }
+}
+```
+
+### CRUD Template
+
+Full CRUD operations scaffold:
+
+```bash
+cnzr generate product --template crud
+```
+
+Generates `src/routes/product.ts` with 5 handlers:
+
+- `listProducts` - GET all items
+- `getProduct` - GET single item by ID
+- `createProduct` - POST new item
+- `updateProduct` - PUT update item
+- `deleteProduct` - DELETE item
+
+```typescript
+import { CenzeroContext } from "cnzr";
+
+const productStore: any[] = [];
+
+// GET - List all products
+export async function listProducts(ctx: CenzeroContext) {
+  // ... pagination support
+}
+
+// GET - Get single product
+export async function getProduct(ctx: CenzeroContext) {
+  // ... by ID
+}
+
+// POST - Create new product
+export async function createProduct(ctx: CenzeroContext) {
+  // ... with validation
+}
+
+// PUT - Update product
+export async function updateProduct(ctx: CenzeroContext) {
+  // ... by ID
+}
+
+// DELETE - Remove product
+export async function deleteProduct(ctx: CenzeroContext) {
+  // ... by ID
+}
+```
+
+Usage:
+```typescript
+import {
+  listProducts,
+  getProduct,
+  createProduct,
+  updateProduct,
+  deleteProduct,
+} from './src/routes/product';
+
+app.get('/products', listProducts);
+app.get('/products/:id', getProduct);
+app.post('/products', createProduct);
+app.put('/products/:id', updateProduct);
+app.delete('/products/:id', deleteProduct);
+```
+
+## Examples
+
+### Generate Simple GET Route
+
+```bash
+cnzr g hello
+```
+
+Creates `src/routes/hello.ts` with basic handler.
+
+### Generate API POST Route
+
+```bash
+cnzr g signup --method post --path /api/auth/signup --template api
+```
+
+Creates `src/routes/signup.ts` with API template.
+
+### Generate Full CRUD
+
+```bash
+cnzr g article --template crud --dir src/api
+```
+
+Creates `src/api/article.ts` with all CRUD operations.
+
+### Custom Path and Method
+
+```bash
+cnzr g dashboard --method get --path /admin/dashboard --dir src/admin
+```
+
+## File Organization
+
+The generator respects your project structure:
+
+```
+project/
+├── src/
+│   ├── routes/           # Default location
+│   │   ├── users.ts
+│   │   └── products.ts
+│   ├── api/              # Custom with --dir
+│   │   └── auth.ts
+│   └── admin/
+│       └── dashboard.ts
+```
+
+## Workflow
+
+1. **Generate route**:
+   ```bash
+   cnzr g users --template crud
+   ```
+
+2. **Import in your app**:
+   ```typescript
+   import { CenzeroApp } from 'cnzr';
+   import { listUsers, getUser, createUser } from './routes/users';
+   
+   const app = new CenzeroApp();
+   
+   app.get('/users', listUsers);
+   app.get('/users/:id', getUser);
+   app.post('/users', createUser);
+   ```
+
+3. **Customize logic**:
+   - Replace in-memory store with database
+   - Add validation logic
+   - Implement business rules
+
+## Best Practices
+
+1. **Use CRUD template** for resource-based APIs
+2. **Use API template** for single endpoints with validation
+3. **Use basic template** for simple routes
+4. **Organize by feature**: Use `--dir` to group related routes
+5. **Name consistently**: Use singular for CRUD (e.g., `user` not `users`)
+
+## Tips
+
+- Generator checks for existing files (use `--force` to overwrite in future versions)
+- CRUD template automatically pluralizes entity names
+- All templates include TypeScript types
+- Error handling is built-in
+- Response formats follow REST conventions
+
+## Integration with File-Based Routing
+
+If using file-based routing, generate routes in your routes directory:
+
+```bash
+cnzr g api/v1/users --template crud --dir src/routes
+```
+
+The file structure will match the URL structure automatically.
+
+## Customization
+
+Edit the generated files to:
+- Add database integration
+- Include authentication/authorization
+- Add input validation schemas
+- Implement caching
+- Add rate limiting
+- Include logging
+
+## Troubleshooting
+
+**File already exists**
+- Choose a different name or remove the existing file
+
+**Permission denied**
+- Check directory permissions
+- Run with appropriate privileges
+
+**Module not found**
+- Ensure cnzr is installed: `npm install cnzr`
+- Check import paths match your project structure

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -1,0 +1,267 @@
+import { mkdir, writeFile, access } from "fs/promises";
+import { join, dirname } from "path";
+import { constants } from "fs";
+
+interface RouteOptions {
+  method?: string;
+  path?: string;
+  dir?: string;
+  template?: "basic" | "crud" | "api";
+}
+
+const ROUTE_TEMPLATES = {
+  basic: (routeName: string, method: string, routePath: string) => `import { CenzeroContext } from "cnzr";
+
+/**
+ * ${method.toUpperCase()} ${routePath}
+ * Handler for ${routeName}
+ */
+export async function ${routeName}Handler(ctx: CenzeroContext) {
+  try {
+    // TODO: Implement your logic here
+    ctx.json({
+      message: "${routeName} route",
+      path: "${routePath}",
+      method: "${method.toUpperCase()}",
+    });
+  } catch (error: any) {
+    ctx.status(500).json({
+      error: "Internal server error",
+      message: error.message,
+    });
+  }
+}
+`,
+
+  api: (routeName: string, method: string, routePath: string) => `import { CenzeroContext } from "cnzr";
+
+/**
+ * ${method.toUpperCase()} ${routePath}
+ * RESTful API handler for ${routeName}
+ */
+export async function ${routeName}Handler(ctx: CenzeroContext) {
+  try {
+    // Validate request
+    if (!ctx.body) {
+      return ctx.status(400).json({
+        error: "Bad Request",
+        message: "Request body is required",
+      });
+    }
+
+    // TODO: Add your business logic here
+    const result = {
+      success: true,
+      data: ctx.body,
+      timestamp: new Date().toISOString(),
+    };
+
+    ctx.json(result);
+  } catch (error: any) {
+    ctx.status(500).json({
+      error: "Internal Server Error",
+      message: error.message,
+    });
+  }
+}
+`,
+
+  crud: (routeName: string, method: string, routePath: string) => {
+    const entityName = routeName.replace(/Handler$/, "");
+    const capitalizedEntity = entityName.charAt(0).toUpperCase() + entityName.slice(1);
+
+    return `import { CenzeroContext } from "cnzr";
+
+// TODO: Replace with your actual database/storage layer
+const ${entityName}Store: any[] = [];
+
+/**
+ * CRUD operations for ${capitalizedEntity}
+ */
+
+// GET - List all ${entityName}s
+export async function list${capitalizedEntity}s(ctx: CenzeroContext) {
+  try {
+    const page = parseInt(ctx.query.page as string) || 1;
+    const limit = parseInt(ctx.query.limit as string) || 10;
+    
+    ctx.json({
+      data: ${entityName}Store,
+      pagination: {
+        page,
+        limit,
+        total: ${entityName}Store.length,
+      },
+    });
+  } catch (error: any) {
+    ctx.status(500).json({ error: error.message });
+  }
+}
+
+// GET - Get single ${entityName}
+export async function get${capitalizedEntity}(ctx: CenzeroContext) {
+  try {
+    const id = ctx.params.id;
+    const item = ${entityName}Store.find((item: any) => item.id === id);
+    
+    if (!item) {
+      return ctx.status(404).json({ error: "${capitalizedEntity} not found" });
+    }
+    
+    ctx.json({ data: item });
+  } catch (error: any) {
+    ctx.status(500).json({ error: error.message });
+  }
+}
+
+// POST - Create new ${entityName}
+export async function create${capitalizedEntity}(ctx: CenzeroContext) {
+  try {
+    const data = ctx.body;
+    
+    // Validation
+    if (!data || Object.keys(data).length === 0) {
+      return ctx.status(400).json({ error: "Request body is required" });
+    }
+    
+    const newItem = {
+      id: Date.now().toString(),
+      ...data,
+      createdAt: new Date().toISOString(),
+    };
+    
+    ${entityName}Store.push(newItem);
+    
+    ctx.status(201).json({ data: newItem });
+  } catch (error: any) {
+    ctx.status(500).json({ error: error.message });
+  }
+}
+
+// PUT - Update ${entityName}
+export async function update${capitalizedEntity}(ctx: CenzeroContext) {
+  try {
+    const id = ctx.params.id;
+    const data = ctx.body;
+    
+    const index = ${entityName}Store.findIndex((item: any) => item.id === id);
+    
+    if (index === -1) {
+      return ctx.status(404).json({ error: "${capitalizedEntity} not found" });
+    }
+    
+    ${entityName}Store[index] = {
+      ...${entityName}Store[index],
+      ...data,
+      updatedAt: new Date().toISOString(),
+    };
+    
+    ctx.json({ data: ${entityName}Store[index] });
+  } catch (error: any) {
+    ctx.status(500).json({ error: error.message });
+  }
+}
+
+// DELETE - Remove ${entityName}
+export async function delete${capitalizedEntity}(ctx: CenzeroContext) {
+  try {
+    const id = ctx.params.id;
+    const index = ${entityName}Store.findIndex((item: any) => item.id === id);
+    
+    if (index === -1) {
+      return ctx.status(404).json({ error: "${capitalizedEntity} not found" });
+    }
+    
+    const deleted = ${entityName}Store.splice(index, 1)[0];
+    
+    ctx.json({ message: "${capitalizedEntity} deleted", data: deleted });
+  } catch (error: any) {
+    ctx.status(500).json({ error: error.message });
+  }
+}
+`;
+  },
+};
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function generateRoute(
+  routeName: string,
+  options: RouteOptions
+) {
+  const {
+    method = "get",
+    path = `/${routeName}`,
+    dir = "src/routes",
+    template = "basic",
+  } = options;
+
+  console.log(`🔧 Generating ${template} route: ${routeName}`);
+
+  try {
+    const routesDir = join(process.cwd(), dir);
+    const fileName = `${routeName}.ts`;
+    const filePath = join(routesDir, fileName);
+
+    // Create routes directory if it doesn't exist
+    await mkdir(routesDir, { recursive: true });
+
+    // Check if file already exists
+    if (await fileExists(filePath)) {
+      console.log(
+        `⚠️  File ${fileName} already exists. Use --force to overwrite.`
+      );
+      return;
+    }
+
+    // Generate route code based on template
+    let routeCode: string;
+
+    if (template === "crud") {
+      routeCode = ROUTE_TEMPLATES.crud(routeName, method, path);
+    } else if (template === "api") {
+      routeCode = ROUTE_TEMPLATES.api(routeName, method, path);
+    } else {
+      routeCode = ROUTE_TEMPLATES.basic(routeName, method, path);
+    }
+
+    // Write file
+    await writeFile(filePath, routeCode);
+
+    console.log(`✅ Route created: ${filePath}`);
+    console.log("");
+    console.log("Usage example:");
+
+    if (template === "crud") {
+      const entityName = routeName.replace(/Handler$/, "");
+      const capitalizedEntity =
+        entityName.charAt(0).toUpperCase() + entityName.slice(1);
+
+      console.log(`
+import { list${capitalizedEntity}s, get${capitalizedEntity}, create${capitalizedEntity}, update${capitalizedEntity}, delete${capitalizedEntity} } from './${dir}/${routeName}';
+
+app.get('${path}', list${capitalizedEntity}s);
+app.get('${path}/:id', get${capitalizedEntity});
+app.post('${path}', create${capitalizedEntity});
+app.put('${path}/:id', update${capitalizedEntity});
+app.delete('${path}/:id', delete${capitalizedEntity});
+      `);
+    } else {
+      console.log(`
+import { ${routeName}Handler } from './${dir}/${routeName}';
+
+app.${method}('${path}', ${routeName}Handler);
+      `);
+    }
+  } catch (error: any) {
+    console.error("❌ Error generating route:", error.message);
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { program } from "commander";
 import { createProject } from "./commands/new";
 import { devServer } from "./commands/dev";
 import { buildProject } from "./commands/build";
+import { generateRoute } from "./commands/generate";
 
 const packageJson = require("../../package.json");
 
@@ -30,5 +31,26 @@ program
   .description("Build the project for production")
   .option('-o, --output <dir>', 'Output directory', 'dist')
   .action(buildProject);
+
+program
+  .command("generate <route-name>")
+  .alias("g")
+  .description("Generate a new route handler")
+  .option("-m, --method <method>", "HTTP method (get, post, put, delete)", "get")
+  .option("-p, --path <path>", "Route path", undefined)
+  .option("-d, --dir <directory>", "Output directory", "src/routes")
+  .option(
+    "-t, --template <template>",
+    "Template type (basic, api, crud)",
+    "basic"
+  )
+  .action((routeName: string, options: any) => {
+    generateRoute(routeName, {
+      method: options.method,
+      path: options.path || `/${routeName}`,
+      dir: options.dir,
+      template: options.template,
+    });
+  });
 
 program.parse();

--- a/test/cli-generate.test.ts
+++ b/test/cli-generate.test.ts
@@ -1,0 +1,123 @@
+import { mkdir, writeFile, access, rm } from "fs/promises";
+import { join } from "path";
+import { constants } from "fs";
+import { generateRoute } from "../src/cli/commands/generate";
+
+declare const describe: any;
+declare const test: any;
+declare const beforeEach: any;
+declare const afterEach: any;
+declare const expect: any;
+declare const jest: any;
+
+describe("CLI Route Generator", () => {
+  const testDir = join(process.cwd(), "test-routes");
+
+  beforeEach(async () => {
+    // Clean up test directory
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore if doesn't exist
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up after tests
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore errors
+    }
+  });
+
+  test("should generate basic route template", async () => {
+    const routeName = "testRoute";
+
+    await generateRoute(routeName, {
+      method: "get",
+      path: "/test",
+      dir: testDir,
+      template: "basic",
+    });
+
+    const filePath = join(testDir, `${routeName}.ts`);
+    const exists = await fileExists(filePath);
+
+    expect(exists).toBe(true);
+  });
+
+  test("should generate API route template", async () => {
+    const routeName = "apiRoute";
+
+    await generateRoute(routeName, {
+      method: "post",
+      path: "/api/test",
+      dir: testDir,
+      template: "api",
+    });
+
+    const filePath = join(testDir, `${routeName}.ts`);
+    const exists = await fileExists(filePath);
+
+    expect(exists).toBe(true);
+  });
+
+  test("should generate CRUD route template", async () => {
+    const routeName = "product";
+
+    await generateRoute(routeName, {
+      method: "get",
+      path: "/products",
+      dir: testDir,
+      template: "crud",
+    });
+
+    const filePath = join(testDir, `${routeName}.ts`);
+    const exists = await fileExists(filePath);
+
+    expect(exists).toBe(true);
+  });
+
+  test("should create directory if not exists", async () => {
+    const routeName = "nested";
+    const nestedDir = join(testDir, "api", "v1");
+
+    await generateRoute(routeName, {
+      method: "get",
+      path: "/nested",
+      dir: nestedDir,
+      template: "basic",
+    });
+
+    const filePath = join(nestedDir, `${routeName}.ts`);
+    const exists = await fileExists(filePath);
+
+    expect(exists).toBe(true);
+  });
+
+  test("should use default options when not provided", async () => {
+    const routeName = "defaultRoute";
+
+    await generateRoute(routeName, {});
+
+    // Should use default dir (src/routes)
+    const defaultPath = join(process.cwd(), "src", "routes", `${routeName}.ts`);
+    
+    // Clean up
+    try {
+      await rm(join(process.cwd(), "src", "routes"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+});
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
- Implement 'cnzr generate' command (alias 'g')
- Support three templates: basic, api, crud
- Basic template: simple handler with error handling
- API template: RESTful with validation
- CRUD template: full resource operations (list, get, create, update, delete)
- Configurable method, path, and output directory
- Auto-create directories if needed
- Prevent overwriting existing files
- Add comprehensive documentation with examples
- Include test suite for generator